### PR TITLE
Moved over to a Queuing System Run by WP-Cron

### DIFF
--- a/includes/ringcentral-activation.inc
+++ b/includes/ringcentral-activation.inc
@@ -80,6 +80,17 @@ $ringcentral_sql = "CREATE TABLE `ringcentral_help` (
 `ringcentral_help_help` TEXT NULL , 
 PRIMARY KEY (`ringcentral_help_id`))";
 dbDelta($ringcentral_sql);
+/* ==============================*/
+/* Create ringcentral_queue table */
+/* ==============================*/
+$ringcentral_sql = "CREATE TABLE `ringcentral_queue` ( 
+`ringcentral_queue_id` INT NOT NULL AUTO_INCREMENT ,
+`ringcentral_post_id` INT NOT NULL ,
+`ringcentral_post_title` VARCHAR(255) NOT NULL , 
+`ringcentral_post_url` VARCHAR(255) NOT NULL ,
+`ringcentral_queue_complete` TINYINT(1) NOT NULL DEFAULT 0, 
+PRIMARY KEY (`ringcentral_queue_id`))";
+dbDelta($ringcentral_sql);
 /* ====================================== */
 /* seed table with control row and basic  */
 /* data if there is no existing row       */

--- a/includes/ringcentral-confirm-optin.inc
+++ b/includes/ringcentral-confirm-optin.inc
@@ -25,5 +25,5 @@ if ($method == 1) { // email confirmation coming in
 $wpdb->query($sql);
 
 // then re-direct to public page confirming the appropriate opt-in method.
-wp_redirect($confirmation_page);
+wp_redirect($confirmation_page); exit();
 ?>

--- a/includes/ringcentral-send-mass-email.inc
+++ b/includes/ringcentral-send-mass-email.inc
@@ -4,13 +4,6 @@
  *
  */
 
-// Send messages even if user closes screen
-ignore_user_abort(true);
-
-$website_name = get_bloginfo('name') ;
-
-$post_url = get_permalink( $post->ID );
-
 /* if you want to let the admins know of an email distribution */
 /* activate this code and update the to email address -- start */
 
@@ -33,11 +26,11 @@ $email_list = $wpdb->get_results( $wpdb->prepare("SELECT `ringcentral_token`, `f
 foreach ( $email_list as $email_contact ) {
 	$unsub_url = add_query_arg(array('rcunsubscribe'=>$mobile_contact->ringcentral_token, 'rcformat'=>'1'), get_site_url());
     
-    $subject = 'A new post has been added to: ' . $website_name;
+    $subject = 'A new post has been added to: ' . $siteName;
     
-    $message = "hi $email_contact->full_name : A new post has been added to:  $website_name <br/>";
+    $message = "hi $email_contact->full_name : A new post has been added to:  $siteName <br/>";
     $message .= "email: $email_contact->email <br/>";
-    $message .= $post->post_title . ": " . $post_url;
+    $message .= $postTitle . ": " . $postUrl;
     $message .= "<br/><br/><br/><br/>To unsubscribe click here: " ;
     $message .= "<a href='" . $unsub_url . "'>Unsubscribe eMail</a>";
     

--- a/includes/ringcentral-send-mass-mobile.inc
+++ b/includes/ringcentral-send-mass-mobile.inc
@@ -4,23 +4,16 @@
  *
  */
 
-// Send messages even if user closes screen
-ignore_user_abort(true);
-
-$website_name = get_bloginfo('name') ;
-
-$mobile_list = $wpdb->get_results( $wpdb->prepare("SELECT `ringcentral_token`, `full_name`, `mobile`
-    FROM `ringcentral_contacts` WHERE `mobile` <> %s AND `mobile_confirmed` = %d", "", 1 ) ); 
-
 $sdk = ringcentral_sdk() ;
-
 $from = ringcentral_get_from();
+
+$mobile_list = $wpdb->get_results( $wpdb->prepare("SELECT `ringcentral_token`, `full_name`, `mobile` FROM `ringcentral_contacts` WHERE `mobile` <> %s AND `mobile_confirmed` = %d", "", 1 ) ); 
 
 foreach ( $mobile_list as $mobile_contact ) {	
 	$unsub_url = add_query_arg(array('rcunsubscribe'=>$mobile_contact->ringcentral_token, 'rcformat'=>'2'), get_site_url());
     
-    $message = "hi $mobile_contact->full_name : A new post has been added to:  $website_name \n\n";
-    $message .= $post->post_title . ": " . $post_url . "\n\n";
+    $message = "hi $mobile_contact->full_name : A new post has been added to:  $siteName \n\n";
+    $message .= $postTitle . ": " . $postUrl . "\n\n";
     $message .= "To unsubscribe follow this link: " ;
     $message .= "$unsub_url ";
     
@@ -50,4 +43,5 @@ foreach ( $mobile_list as $mobile_contact ) {
 	// Sleep for 1.8 seconds to prevent 40/min penalty
 	usleep(1800000);
 }
+
 ?>

--- a/includes/ringcentral-unsubscribe.inc
+++ b/includes/ringcentral-unsubscribe.inc
@@ -21,5 +21,5 @@ if ($method == 1) { // email unsubscription coming in
 $wpdb->query($sql);
 
 // then re-direct to public page confirming the email removal.
-wp_redirect($unsub_confirm_page);
+wp_redirect($unsub_confirm_page); exit();
 ?>

--- a/ringcentral.php
+++ b/ringcentral.php
@@ -281,8 +281,6 @@ add_action( 'ringcentral_send_notifications', 'ringcentral_check_queue' );
 
 function ringcentral_check_queue() {
 	global $wpdb;
-
-	$wpdb->query("UPDATE `ringcentral_queue` SET `ringcentral_queue_complete` = 0");
 	
 	$result_queue = $wpdb->get_row( $wpdb->prepare("SELECT `ringcentral_queue_id` AS `id`, `ringcentral_post_title` AS `title`, `ringcentral_post_url` AS `url`
         FROM `ringcentral_queue`


### PR DESCRIPTION
• Setup a table to store newly published posts
• Setup a cron to run every 5 minutes
• Updated ringcentral.php and send-mass files

Instead of trying to send all files immediately and running into time limits, publishing a post pushes the request into a queue table.  The table is checked every 5 minutes, and if a new post is found it triggers the email and SMS messaging systems to run in the background.  This prevents the user from having to wait for completion of sending before seeing a post success message, as well as prevents the time limit issue for larger groups of SMS messages.